### PR TITLE
Fix product id checks

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -38,6 +38,9 @@ class ProductController extends Controller
 
     public function edit($id) {
         $products = session()->get('products', []);
+        if (! isset($products[$id])) {
+            abort(404);
+        }
         $product = $products[$id];
         return view('products.form', compact('product', 'id'));
     }
@@ -50,6 +53,9 @@ class ProductController extends Controller
 ]);
 
         $products = session()->get('products', []);
+        if (! isset($products[$id])) {
+            abort(404);
+        }
         $products[$id] = [
             'name' => $request->name,
             'description' => $request->description,
@@ -65,12 +71,18 @@ class ProductController extends Controller
 
     public function show($id) {
         $products = session()->get('products', []);
+        if (! isset($products[$id])) {
+            abort(404);
+        }
         $product = $products[$id];
         return view('products.show', compact('product'));
     }
 
     public function destroy($id) {
     $products = session()->get('products', []);
+    if (! isset($products[$id])) {
+        abort(404);
+    }
     unset($products[$id]);
     $products = array_values($products); // reset index
     session(['products' => $products]);

--- a/resources/views/products/form.blade.php
+++ b/resources/views/products/form.blade.php
@@ -14,15 +14,15 @@
         @csrf
 
         <x-form.group for="name" label="Name">
-            <input type="text" name="name" class="form-control" required value="{{ $product['name'] ?? '' }}">
+            <input id="name" type="text" name="name" class="form-control" required value="{{ $product['name'] ?? '' }}">
         </x-form.group>
 
         <x-form.group for="description" label="Description">
-            <textarea name="description" class="form-control" required>{{ $product['description'] ?? '' }}</textarea>
+            <textarea id="description" name="description" class="form-control" required>{{ $product['description'] ?? '' }}</textarea>
         </x-form.group>
 
         <x-form.group for="price" label="Price">
-            <input type="number" name="price" class="form-control" required value="{{ $product['price'] ?? '' }}">
+            <input id="price" type="number" name="price" class="form-control" required value="{{ $product['price'] ?? '' }}">
         </x-form.group>
 
         <button type="submit" class="btn btn-primary">Submit</button>

--- a/tests/Feature/ProductInvalidTest.php
+++ b/tests/Feature/ProductInvalidTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ProductInvalidTest extends TestCase
+{
+    /**
+     * Ensure invalid product id returns 404.
+     */
+    public function test_edit_invalid_product_returns_404(): void
+    {
+        $response = $this->get('/products/edit/999');
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing product IDs in `ProductController`
- ensure form input labels match by adding `id` attributes
- add a test for invalid product access

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9f1ba29483279fc60069bc947934